### PR TITLE
Bugfixes en Verbeteringen

### DIFF
--- a/quick-menu/config.js
+++ b/quick-menu/config.js
@@ -57,7 +57,7 @@ function getByPath(object, path) {
 }
 function setByPath(object, path, value) {
   let ob = object;
-  const pathSplit = path.spli(".");
+  const pathSplit = path.split(".");
   for (let i = 0; i < pathSplit.length - 1; i++) {
     ob = ob[pathSplit[i]];
   }

--- a/widgets/assignments.js
+++ b/widgets/assignments.js
@@ -191,7 +191,7 @@ class TakenWidget extends WidgetBase {
           ).toLocaleTimeString("nl-NL", {
             hour: "2-digit",
             minute: "2-digit",
-          })} • ${element.courses?.[0]?.name || "TODO"}`;
+          })} • ${element.courses?.[0]?.name || "Unknown Course"}`;
           metadataSpan.classList.add("task-description");
 
           detailsDiv.append(titleSpan, metadataSpan);


### PR DESCRIPTION
Typfout opgelost in Quick Menu Configuratie
Een typfout in quick-menu/config.js is gecorrigeerd: path.spli('.') is aangepast naar path.split('.') in de functie setByPath.

Verbeterde Gebruikerservaring in Assignments-widget De tijdelijke tekst 'TODO' is vervangen door 'Unknown Course' in widgets/assignments.js wanneer de cursusnaam niet beschikbaar is. Dit zorgt voor een professionelere en meer informatieve weergave voor gebruikers.