### PR TITLE
cookie based detectie mechanisme voor andere extensies 

### DIFF
--- a/main-features/main.js
+++ b/main-features/main.js
@@ -359,7 +359,7 @@ function setExtensionDetectionCookie() {
   expires.setDate(expires.getDate() + 365); // cookie gaat weg na 1 jaar
   
   const expireString = expires.toUTCString();
-  // ik weet dat direct toegang tot document.cookie niet goed is maar, ik weet niet hoe anders ik dit moet doen, shit code
+  // ik weet dat direct toegang tot document.cookie niet goed is, maar ik weet niet hoe anders ik dit moet doen, shit code
   document.cookie = `smpp_extension_active=true;expires=${expireString};path=/;SameSite=Lax`;
   document.cookie = `smpp_version=${version};expires=${expireString};path=/;SameSite=Lax`;
   


### PR DESCRIPTION
waarom?

Andere extensies kunnen nu checken of sm++ actief is via cookies ipv alleen de css class op de body. dit is handiger omdat je niet hoeft te wachten tot de dom geladen is en je kan ook de versie zien

wat doet het?
zet 2 cookies
1) smpp_extension_active=true - is smpp aan?
2) smpp_version={versie} - welk versie?

zo kunnen andere extensies  hun logica aanpassen als SMPP draait, conflicts vermijden etc