### PR TITLE
Improve quick menu keyboard accessibility

### DIFF
--- a/src/main-features/keybinds.ts
+++ b/src/main-features/keybinds.ts
@@ -12,28 +12,109 @@ import {
 
 export type Keybind = Uppercase<string> | symbol | "None" | "Space";
 
-document.addEventListener("keyup", async (e) => {
-  if (e.target?.tagName === "INPUT") return;
-  if (e.target?.tagName === "TEXTAREA") return;
-  if (document.getElementById("tinymce")) return;
+function hasKeybinds(): boolean {
+  return (
+    typeof keybinds !== "undefined" &&
+    !!keybinds &&
+    Object.keys(keybinds).length > 0
+  );
+}
 
-  const key =
-    e.key === " " ? "Space" : e.key.length === 1 ? e.key.toUpperCase() : e.key; // this is so readable i love it
+function isTextEditingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+
+  const tagName = target.tagName.toUpperCase();
+
+  if (tagName === "INPUT") return true;
+  if (tagName === "TEXTAREA") return true;
+  if (tagName === "SELECT") return true;
+
+  if (target.isContentEditable) return true;
 
   if (
-    (typeof keybinds === "undefined" ||
-      !keybinds ||
-      Object.keys(keybinds).length === 0) &&
-    key === ":"
+    target.closest("[contenteditable='true']") ||
+    target.closest("[contenteditable='']") ||
+    target.closest("[contenteditable='plaintext-only']") ||
+    target.closest("[role='textbox']") ||
+    target.closest(".tox-tinymce") ||
+    target.closest(".tox-edit-area") ||
+    target.closest(".mce-content-body")
   ) {
-    do_qm("dmenu");
+    return true;
+  }
+
+  const activeElement = document.activeElement;
+
+  if (activeElement instanceof HTMLElement && activeElement !== target) {
+    const activeTagName = activeElement.tagName.toUpperCase();
+
+    if (activeTagName === "INPUT") return true;
+    if (activeTagName === "TEXTAREA") return true;
+    if (activeTagName === "SELECT") return true;
+    if (activeElement.isContentEditable) return true;
+
+    if (
+      activeElement.closest("[contenteditable='true']") ||
+      activeElement.closest("[contenteditable='']") ||
+      activeElement.closest("[contenteditable='plaintext-only']") ||
+      activeElement.closest("[role='textbox']") ||
+      activeElement.closest(".tox-tinymce") ||
+      activeElement.closest(".tox-edit-area") ||
+      activeElement.closest(".mce-content-body")
+    ) {
+      return true;
+    }
+  }
+
+  if (document.getElementById("tinymce")) return true;
+
+  return false;
+}
+
+function normalizeKey(e: KeyboardEvent): Keybind {
+  return e.key === " "
+    ? "Space"
+    : e.key.length === 1
+      ? e.key.toUpperCase()
+      : e.key;
+}
+
+function openQuickMenuFromKeyboard(source: string): void {
+  do_qm(source);
+}
+
+document.addEventListener("keydown", async (e) => {
+  if (e.defaultPrevented) return;
+  if (e.repeat) return;
+  if (isTextEditingTarget(e.target)) return;
+
+  const isQuickMenuShortcut =
+    (e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "k";
+
+  if (isQuickMenuShortcut) {
+    e.preventDefault();
+    openQuickMenuFromKeyboard("dmenu");
+  }
+});
+
+document.addEventListener("keyup", async (e) => {
+  if (e.defaultPrevented) return;
+  if (isTextEditingTarget(e.target)) return;
+
+  const key = normalizeKey(e);
+
+  if (!hasKeybinds()) {
+    if (key === ":") {
+      openQuickMenuFromKeyboard("dmenu");
+    }
+
     return;
   }
 
   // General
   switch (key) {
     case keybinds.dmenu:
-      do_qm(keybinds.dmenu);
+      openQuickMenuFromKeyboard(keybinds.dmenu);
       break;
     case keybinds.settings:
       openSettingsWindow(e);


### PR DESCRIPTION
## What changed

This PR improves the Quick Menu keyboard behaviour.

### Added

* `Ctrl + K` / `Cmd + K` shortcut to open the Quick Menu.
* Safer detection for text-editing fields.

### Fixed

* The Quick Menu no longer opens while typing in:

  * inputs
  * textareas
  * selects
  * contenteditable fields
  * textbox-like elements
  * TinyMCE-like editor areas

### Why

The Quick Menu is one of the most useful Smartschool++ features, but it should not interrupt users while they are typing. This makes the feature feel more reliable and modern while keeping the existing `:` shortcut.

### Testing

* Ran `npx prettier --write src/main-features/keybinds.ts`
* Ran `npm run build`
* Confirmed the build succeeds
* Tested that `:` still opens the Quick Menu outside text fields
* Tested that `Ctrl + K` / `Cmd + K` opens the Quick Menu
* Tested that shortcuts do not trigger while typing in input fields
